### PR TITLE
Replace deprecated ESI domain with current standard domain

### DIFF
--- a/MarketScript.gs
+++ b/MarketScript.gs
@@ -725,7 +725,7 @@ function getMarketJson(itemId, regionId, orderType)
     orderType = orderType.toLowerCase();
 
     // Setup variables for the market endpoint we want
-    var marketUrl = 'https://esi.tech.ccp.is/latest/markets/' + regionId + '/orders/';
+    var marketUrl = 'https://esi.evetech.net/latest/markets/' + regionId + '/orders/';
     var parameterUrl = '?order_type=' + orderType + '&type_id=' + itemId;
     Logger.log('Pulling market orders from url: ' + marketUrl + parameterUrl)
     var fullUrl = marketUrl + parameterUrl;


### PR DESCRIPTION
Hi @nuadi

I know that you are no longer maintaining this project, but I had one line fix to keep the `getStationMarketPrice` function working so I figured I'd send it to you anyway. Im still using this function on some old sheets.

Essentially, CCP has stopped forwarding *esi.tech.ccp.is* to *esi.evetech.net* (as per https://developers.eveonline.com/blog/article/removal-of-redirect-from-.tech.ccp.is-on-jan-7th) so this PR simply updates the URL 

Hopefully this helps someone else